### PR TITLE
Aarch64 Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,9 @@ RUN /get_dependencies.sh download_deb_pkg libusb-dev-amd64 "http://mirrors.kerne
     /get_dependencies.sh download_deb_pkg libusb-dev-i386 "http://mirrors.kernel.org/ubuntu/pool/main/libu/libusb-1.0/libusb-1.0-0-dev_1.0.23-2build1_i386.deb" && \
     /get_dependencies.sh download_deb_pkg libusb-armhf "http://mirrordirector.raspbian.org/raspbian/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.24-2_armhf.deb" && \
     /get_dependencies.sh download_deb_pkg libusb-dev-armhf "http://mirrordirector.raspbian.org/raspbian/pool/main/libu/libusb-1.0/libusb-1.0-0-dev_1.0.24-2_armhf.deb" && \
-    /get_dependencies.sh download_deb_pkg libstdc++-linux-armhf "http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-10-cross/libstdc++-10-dev-armhf-cross_10-20200411-0ubuntu1cross1_all.deb"
+    /get_dependencies.sh download_deb_pkg libstdc++-linux-armhf "http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-10-cross/libstdc++-10-dev-armhf-cross_10-20200411-0ubuntu1cross1_all.deb" && \
+    /get_dependencies.sh download_deb_pkg libusb-aarch64 "http://deb.debian.org/debian/pool/main/libu/libusb-1.0/libusb-1.0-0-dev_1.0.22-2_arm64.deb"
+
 
 
 RUN /get_dependencies.sh patch_macos_sdk && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,14 @@ RUN echo "[custom]" >> /etc/pacman.conf && \
 
 # Install prerequisites for the following targets:
 #  - Linux (AMD64)
-#  - Linux (ARM)
+#  - Linux (ARM 32-bit)
+#  - Linux (AArch64)
 #  - Windows (AMD64)
 #  - macOS (x86_32/AMD64)
 #  - WebAssembly
 RUN pacman -S --noconfirm tup clang gcc binutils wget && \
     pacman -S --noconfirm arm-linux-gnueabihf-gcc arm-linux-gnueabihf-binutils && \
+    pacman -S --noconfirm aarch64-linux-gnu-gcc && \
     pacman -S --noconfirm mingw-w64-gcc mingw-w64-binutils p7zip && \
     pacman -S --noconfirm apple-darwin-osxcross && \
     pacman -S --noconfirm emscripten
@@ -33,9 +35,9 @@ RUN /get_dependencies.sh download_deb_pkg libusb-dev-amd64 "http://mirrors.kerne
     /get_dependencies.sh download_deb_pkg libusb-dev-i386 "http://mirrors.kernel.org/ubuntu/pool/main/libu/libusb-1.0/libusb-1.0-0-dev_1.0.23-2build1_i386.deb" && \
     /get_dependencies.sh download_deb_pkg libusb-armhf "http://mirrordirector.raspbian.org/raspbian/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.24-2_armhf.deb" && \
     /get_dependencies.sh download_deb_pkg libusb-dev-armhf "http://mirrordirector.raspbian.org/raspbian/pool/main/libu/libusb-1.0/libusb-1.0-0-dev_1.0.24-2_armhf.deb" && \
-    /get_dependencies.sh download_deb_pkg libstdc++-linux-armhf "http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-10-cross/libstdc++-10-dev-armhf-cross_10-20200411-0ubuntu1cross1_all.deb" && \
-    /get_dependencies.sh download_deb_pkg libusb-aarch64 "http://deb.debian.org/debian/pool/main/libu/libusb-1.0/libusb-1.0-0-dev_1.0.22-2_arm64.deb"
-
+    /get_dependencies.sh download_deb_pkg libusb-aarch64 "http://deb.debian.org/debian/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.24-2_arm64.deb" && \
+    /get_dependencies.sh download_deb_pkg libusb-dev-aarch64 "http://deb.debian.org/debian/pool/main/libu/libusb-1.0/libusb-1.0-0-dev_1.0.24-2_arm64.deb" && \
+    /get_dependencies.sh download_deb_pkg libstdc++-linux-armhf "http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-10-cross/libstdc++-10-dev-armhf-cross_10-20200411-0ubuntu1cross1_all.deb"
 
 
 RUN /get_dependencies.sh patch_macos_sdk && \

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ If something fails you can enter the container interactively with `docker run -i
   1. `brew install libusb`
   2. Navigate to this directory and run `make`
 
+### ARM64 Linux
+  1. `sudo apt install libusb-1.0-0-dev libncurses5`
+  2. Install Clang
+  3. Navigate to this directory
+  4. Run `tup init` and then `tup`. The shared library will be under the `build` directory.
+
 ## Using `libfibre`
 
 The API is documented in [libfibre.h](include/fibre/libfibre.h).

--- a/Tupfile.lua
+++ b/Tupfile.lua
@@ -53,7 +53,7 @@ elseif string.find(machine, "arm.*%-linux%-.*") then
 elseif string.find(machine, "aarch64.*%-linux%-.*") then
     outname = 'libfibre-linux-aarch64.so'
     LDFLAGS += '-lpthread -Wl,--version-script=libfibre.version -Wl,--gc-sections'
-    STRIP = false
+    STRIP = not DEBUG
 elseif string.find(machine, "x86_64.*-mingw.*") then
     outname = 'libfibre-windows-amd64.dll'
     LDFLAGS += '-lpthread -Wl,--version-script=libfibre.version'
@@ -141,7 +141,7 @@ tup.frule{
 if STRIP then
     tup.frule{
         inputs={compile_outname},
-        command='strip --strip-all --discard-all %f -o %o',
+        command=tup.getconfig("BINUTILS_PREFIX")..'strip --strip-all --discard-all %f -o %o',
         outputs={outname}
     }
 end

--- a/Tupfile.lua
+++ b/Tupfile.lua
@@ -50,6 +50,10 @@ elseif string.find(machine, "arm.*%-linux%-.*") then
     outname = 'libfibre-linux-armhf.so'
     LDFLAGS += '-lpthread -Wl,--version-script=libfibre.version -Wl,--gc-sections'
     STRIP = false
+elseif string.find(machine, "aarch64.*%-linux%-.*") then
+    outname = 'libfibre-linux-aarch64.so'
+    LDFLAGS += '-lpthread -Wl,--version-script=libfibre.version -Wl,--gc-sections'
+    STRIP = false
 elseif string.find(machine, "x86_64.*-mingw.*") then
     outname = 'libfibre-windows-amd64.dll'
     LDFLAGS += '-lpthread -Wl,--version-script=libfibre.version'

--- a/configs/linux-aarch64.config
+++ b/configs/linux-aarch64.config
@@ -1,0 +1,6 @@
+CONFIG_DEBUG=false
+CONFIG_STRICT=true
+CONFIG_CC="aarch64-linux-gnu-g++"
+CONFIG_CFLAGS="-I$THIRD_PARTY./third_party/libusb-dev-aarch64/usr/include/libusb-1.0"
+CONFIG_LDFLAGS="$THIRD_PARTY./third_party/libusb-aarch64/usr/lib/aarch64-linux-gnu/libusb-1.0.so.0"
+CONFIG_USE_PKGCONF=false

--- a/configs/linux-aarch64.config
+++ b/configs/linux-aarch64.config
@@ -1,6 +1,7 @@
 CONFIG_DEBUG=false
 CONFIG_STRICT=true
 CONFIG_CC="aarch64-linux-gnu-g++"
+CONFIG_BINUTILS_PREFIX="aarch64-linux-gnu-"
 CONFIG_CFLAGS="-I$THIRD_PARTY./third_party/libusb-dev-aarch64/usr/include/libusb-1.0"
 CONFIG_LDFLAGS="$THIRD_PARTY./third_party/libusb-aarch64/usr/lib/aarch64-linux-gnu/libusb-1.0.so.0"
 CONFIG_USE_PKGCONF=false


### PR DESCRIPTION
This branch is intended to bring aarch64 linux support to fibre-cpp.

Notes:
After installing clang and libncurses5, fibre can be built locally from this repo on an RPi4 running 64 bit raspbian.
Currently, docker support has not been tested. The libusb package source has been added to the Dockerfile.